### PR TITLE
feat: error boundary 적용

### DIFF
--- a/src/app/(contents)/beers/error.tsx
+++ b/src/app/(contents)/beers/error.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import ErrorInfo from '@/components/errorInfo';
+import { useEffect } from 'react';
+
+/**
+ * @returns 에러 바운더리 (beer page)
+ */
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <ErrorInfo
+      title={'맥주 정보를 불러오는 데 실패하였습니다 :('}
+      onClick={() => reset()}
+    />
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import ErrorInfo from '@/components/errorInfo';
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html>
+      <body className="w-screen h-screen flex items-center justify-center">
+        <ErrorInfo
+          title={'예상치 못한 에러가 발생했습니다 :('}
+          onClick={() => reset()}
+        />
+      </body>
+    </html>
+  );
+}

--- a/src/components/errorInfo.tsx
+++ b/src/components/errorInfo.tsx
@@ -1,0 +1,18 @@
+type ErrorInfoProps = {
+  title: string;
+  onClick: () => void;
+};
+
+export default function ErrorInfo({ title, onClick }: ErrorInfoProps) {
+  return (
+    <div className="flex flex-col justify-center items-center">
+      <p className="text-pageHead text-card-description">{title}</p>
+      <button
+        onClick={onClick}
+        className="mt-4 px-4 py-2 bg-card-hoverBorder text-white rounded"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## 💡 이슈 번호

close #27 

## 📖 작업 내용

- [X] error boundary 적용

## 🔎 알게 된 점

- Server-side Expected Error 의 경우, try-catch 보단.. 에러를 명시적으로 작성하는 것이 좋다고 한다..! 
   굳이 error를 던질 필요가 없다는 것 같다
- Unexpected Error의 경우, 전역적 또는 지역적 처리가 존재했다
   app 바로 하위에 error.tsx 파일 생성 -> 전역적으로 error를 캐치하며, html 부터 전체적으로 가지고 있다
   반면, 원하는 위치에 error.tsx 파일 생성 -> 하위 요소들에서만 error를 캐치한다
 - 두 가지가 모두 적용되어 있다면 에러 발생 지점으로부터 가까운 위치에 존재하는 error boundary에 붙잡히게 된다는 점을 알게 되었당